### PR TITLE
Encode request body in UTF-8

### DIFF
--- a/src/main/java/me/pagar/api/http/client/OkClient.java
+++ b/src/main/java/me/pagar/api/http/client/OkClient.java
@@ -16,6 +16,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
+import java.nio.charset.StandardCharsets;
+
 import me.pagar.api.http.request.HttpBodyRequest;
 import me.pagar.api.http.request.HttpMethod;
 import me.pagar.api.http.request.HttpRequest;
@@ -208,7 +210,7 @@ public class OkClient implements HttpClient {
 
             // set request body
             requestBody = okhttp3.RequestBody.create(okhttp3.MediaType.parse(contentType),
-                    ((HttpBodyRequest) httpRequest).getBody().getBytes());
+                    ((HttpBodyRequest) httpRequest).getBody().getBytes(StandardCharsets.UTF_8));
         } else {
 
             List<SimpleEntry<String, Object>> parameters = httpRequest.getParameters();


### PR DESCRIPTION
The encoding was using the system's default encoding. On systems where the default is not UTF-8, the requests failed with 400 whem there was words with accents, for exemple in the custormer's name.

Caso real em que a falha ocorreu:

Usamos a biblioteca para criar um pedido com pagamento em que o nome do customer tinha acento, como por exemplo "José Assunção". A criação do pedido falhava com 400 neste caso sem nenhuma outra informação no MErrorException. Porém quando o nome do customer não tinha acentos, como em "Rita Maia", o pedido era criado com sucesso.

O sistema em produção estava rodando em uma máquina virtual windows na nuvem.

Os pedidos também eram realizados com sucesso, independente da existência ou não de acentuação nos nomes, quando fazíamos testes a partir de uma máquina linux.

 Analisando vimos que o encoding padrão do java no sistema windows era o ANSI, e na máquina linux era o UTF-8. No código vimos que o header "content-type" era sempre configurado com UTF-8. Porém a obtenção do array de bytes do corpo da requisição não especificava o encoding, utilizando o padrão do sistema.